### PR TITLE
set type of --threads to int

### DIFF
--- a/bin/transcriptm
+++ b/bin/transcriptm
@@ -79,7 +79,7 @@ transcriptm --paired_end sample1-1.fq.gz sample1-2.fq.gz sample2-1.fq.gz sample2
     parser.add_argument("--paired_end",nargs="+", dest="paired_end", help="Input files: paired sequences files of raw metatranscriptomics reads (.fq.gz format)\n  e.g. --paired_end sample1_1.fq.gz sample1_2.fq.gz sample2_1.fq.gz sample2_2.fq.gz",required=True)
     parser.add_argument("--metaG_contigs", dest="metaG_contigs", help="All contigs from the reference metagenome in a fasta file",required=True)
     parser.add_argument("--dir_bins", dest="dir_bins", help="Directory which contains several annotated population genomes (bins)\n -> gff format, the others files would be ignored",required=True)
-    parser.add_argument("--threads", dest="threads", help="Number of threads to use", default=20)
+    parser.add_argument("--threads", dest="threads", help="Number of threads to use", default=20, type=int)
     
     # check if the db is an environment variable
     db_path=None    


### PR DESCRIPTION
Hey Eleanore!

Just a pretty simple bugfix - otherwise it errors out when a non-default number of threads is specified, when it tries to %d in the transcriptm call.

thanks
ben
